### PR TITLE
Remove pause from Windows compile_scripts.cmd

### DIFF
--- a/compile_scripts.cmd
+++ b/compile_scripts.cmd
@@ -8,5 +8,4 @@ IF NOT EXIST bot.jar (
     echo Compiling scripts ...
     echo.
     call %antpath%ant -f build.xml compile-scripts
-    pause
 )


### PR DESCRIPTION
The pause causes compiling scripts in the client to hang forever on Windows, forcing the use of taskmanager to quit the app.